### PR TITLE
Add --no-warn-unused-ignores as default arg

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,6 @@
     entry: mypy
     language: python
     'types': [python]
-    args: ["--ignore-missing-imports", "--scripts-are-modules"]
+    args: ["--ignore-missing-imports", "--scripts-are-modules", "--no-warn-unused-ignores"]
     require_serial: true
     additional_dependencies: []


### PR DESCRIPTION
See https://github.com/pre-commit/mirrors-mypy/issues/6

This would remove the need to install all stub packages and py.typed dependencies in `additional_dependencies`.