### PR TITLE
Add link to GitHub Sponsors + Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: asottile
+open_collective: pre-commit


### PR DESCRIPTION
at the time of writing I am currently unemployed.  I'd love to make open
source a full time career.  if you or your company is deriving value from
this free software, please consider [sponsoring] or [supporting].

[sponsoring]: https://github.com/sponsors/asottile
[supporting]: https://opencollective.com/pre-commit

Committed via https://github.com/asottile/all-repos