### PR TITLE
Run mypy on type stubs as well

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: mypy
     entry: mypy
     language: python
-    'types': [python]
+    types_or: [python, pyi]
     args: ["--ignore-missing-imports", "--scripts-are-modules"]
     require_serial: true
     additional_dependencies: []


### PR DESCRIPTION
Currently, the mypy pre-commit hook will ignore changes of stubs (.pyi) files since they are not part of the python type. This update the hook to use the types_or config value to ensure that mypy is run if corresponding stub files change. [Black](https://github.com/psf/black/blob/main/.pre-commit-hooks.yaml) which supports formatting python files and pyi stub files was also updated to fix a similar bug where pyi files were not considered.