### PR TITLE
Update entry for mypy

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: mypy
     name: mypy
     description: ''
-    entry: mypy
+    entry: mypy .
     language: python
     'types_or': [python, pyi]
     args: ["--ignore-missing-imports", "--scripts-are-modules"]


### PR DESCRIPTION
Noticed `--exclude` wasn't working properly before this edition. 

## How to test
1. Create a folder with a migrations folder inside this folder and a bunch of .py files with typing errors
2. Add an --exclude flag (or on mypy.ini) with exclusion to migrations
3. Before, mypy bypassed --exclude .. Now, everything works fine 