### PR TITLE
Remove example flag that we must not speak of

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To change the arguments, override the `args` as follows:
 ```yaml
     hooks:
     -   id: mypy
-        args: [--no-strict-optional, --ignore-missing-imports]
+        args: [--strict, --ignore-missing-imports]
 ```
 
 Because `pre-commit` runs `mypy` from an isolated virtualenv (without your


### PR DESCRIPTION
I just had a user copy-paste this, thinking it was the recommended way to run mypy. I'd prefer if users who copy-paste things didn't pick up a flag that's highly discouraged